### PR TITLE
Update branch name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cryspy @ git+https://github.com/ikibalin/cryspy.git@bravis_type_fix
 --extra-index-url https://easyscience.github.io/pypi
-easysciencecore @ git+https://github.com/easyScience/easyCore.git@easyCrystallography_Split
+easysciencecore @ git+https://github.com/easyScience/easyCore.git
 easycrystallography @ git+https://github.com/easyScience/easyCrystallography.git@develop
 cfml==0.0.1
 gsasii==0.0.1


### PR DESCRIPTION
Fixed branch name, since `easyCrystallography_Split` has been already merged and deleted...