### PR TITLE
Quicker cfml

### DIFF
--- a/easyDiffractionLib/Interfaces/CFML.py
+++ b/easyDiffractionLib/Interfaces/CFML.py
@@ -144,7 +144,7 @@ class CFML(InterfaceTemplate):
         ident = str(self.__identify(phase_obj))
         self.calculator.remove_phase(ident)
 
-    def fit_func(self, x_array: np.ndarray) -> np.ndarray:
+    def fit_func(self, x_array: np.ndarray, *args, **kwargs) -> np.ndarray:
         """
         Function to perform a fit
         :param x_array: points to be calculated at
@@ -152,7 +152,7 @@ class CFML(InterfaceTemplate):
         :return: calculated points
         :rtype: np.ndarray
         """
-        return self.calculator.calculate(x_array)
+        return self.calculator.calculate(x_array, **kwargs)
 
     def get_hkl(self, x_array: np.ndarray = None, idx=None, phase_name=None, encoded_name=False) -> dict:
         return self.calculator.get_hkl(x_array)

--- a/easyDiffractionLib/calculators/CFML.py
+++ b/easyDiffractionLib/calculators/CFML.py
@@ -21,6 +21,9 @@ class CFML:
         self.this_x_array = None
 
     def createConditions(self, job_type="N"):
+        pattern_type = 'NEUT_2THE       '
+        if job_type == "X":
+            pattern_type = 'XRAY_2THE       '
         self.conditions = {
             "lamb": 1.54,
             "u_resolution": 0.01,
@@ -29,6 +32,7 @@ class CFML:
             "x_resolution": 0.0,
             "y_resolution": 0.0,
             "z_resolution": 0.0,
+            "pattern_type": pattern_type,
         }
 
     def conditionsUpdate(self, _, **kwargs):
@@ -98,6 +102,8 @@ class CFML:
             job_info.w_resolution = self.conditions["w_resolution"]
             job_info.x_resolution = self.conditions["x_resolution"]
             job_info.y_resolution = self.conditions["y_resolution"]
+            job_info.y_resolution = self.conditions["y_resolution"]
+            job_info.pattern_type = self.conditions["pattern_type"]
             job_info.lambdas = (self.conditions["lamb"], self.conditions["lamb"])
             job_info.bkg = 0.0
 
@@ -112,7 +118,7 @@ class CFML:
                 )
 
                 diffraction_pattern = CFML_api.DiffractionPattern(
-                    job_info, reflection_list, cell.reciprocal_cell_vol
+                    job_info, reflection_list, self.scale
                 )
             except Exception as e:
                 for cif in cifs:

--- a/easyDiffractionLib/elements/Backgrounds/Point.py
+++ b/easyDiffractionLib/elements/Backgrounds/Point.py
@@ -101,6 +101,7 @@ class PointBackground(Background):
         :param kwargs: Any additional kwargs
         """
         super(PointBackground, self).__init__('point_background', *args, linked_experiment=linked_experiment, **kwargs)
+        self.x_points = self.x_sorted_points # do it just once, since it doesn't change and evaluation is expensive
 
     def calculate(self, x_array: np.ndarray) -> np.ndarray:
         """
@@ -118,7 +119,8 @@ class PointBackground(Background):
         # y = np.zeros_like(reduced_x)
 
         # low_x = x_array.flat[0] - 1e-10
-        x_points = self.x_sorted_points
+
+        x_points = self.x_points
         if not len(x_points):
             return np.zeros_like(x_array)
         # low_y = 0
@@ -173,7 +175,7 @@ class PointBackground(Background):
         :return: Sorted x-values
         :rtype: np.ndarray
         """
-        x = np.array([item.x.raw_value for item in self])
+        x = np.array([item.x.raw_value for item in self])  # *** EXPENSIVE ****
         x.sort()
         return x
 
@@ -185,8 +187,8 @@ class PointBackground(Background):
         :return: Sorted y-values
         :rtype: np.ndarray
         """
-        idx = np.array([item.x.raw_value for item in self]).argsort()
-        y = np.array([item.y.raw_value for item in self])
+        idx = np.array(self.x_points).argsort()
+        y = np.array([item.y.raw_value for item in self])  # *** EXPENSIVE ****
         return y[idx]
 
     @property
@@ -208,7 +210,7 @@ class PointBackground(Background):
         """
         if not isinstance(item, BackgroundPoint):
             raise TypeError('Item must be a BackgroundPoint')
-        if item.x.raw_value in self.x_sorted_points:
+        if item.x.raw_value in self.x_points:
             raise AttributeError(f'An BackgroundPoint at {item.x.raw_value} already exists.')
         super(PointBackground, self).append(item)
 


### PR DESCRIPTION
Refactored parts of the cfml interface and calculator so that running fits is significantly quicker now.
There are still two large contributors (apart of the obvious profile calculations):
1 - I/O of reading and writing temp files
2 - undo stack update between optimization steps (required for constraints)

1. will be addressed by applying changes from the `io_serialization` branch of easyCore