### PR TITLE
check if setting pip config helps with module installation

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -40,6 +40,12 @@ jobs:
       with:
         python-version: 3.8
 
+    - name: Enable extra repository
+      shell: bash
+      run: |
+        pip config --user set global.extra-index-url https://easyscience.github.io/pypi/
+        pip config --user set global.trusted-host easyscience.github.io
+
     - name: Some logging
       shell: bash
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,15 +43,11 @@ cryspy = { git = 'https://github.com/ikibalin/cryspy.git', rev = 'bravis_type_fi
 # easyCrystallography = "^0.3.0"
 easyScienceCore = { git = 'https://github.com/easyScience/easyCore.git', rev = 'master' }
 easyCrystallography = { git = 'https://github.com/easyScience/easyCrystallography.git', rev = 'master' }
-
 pycifrw = "^4.4.1"
-CFML = {version = '^0.0.1', optional=true}
+CFML = '^0.0.1'
 GSASII = {version = '^0.0.1', optional=true}
-"diffpy.pdffit2" = {version = "0.0.0", optional=true}
-"diffpy.utils" = {version = "^3.0.0", optional=true}
-
-[tool.poetry.extras]
-additional = ["CFML", "GSASII", "diffpy.pdffit2"]
+"diffpy.pdffit2" = "0.0.0"
+"diffpy.utils" = "^3.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1"


### PR DESCRIPTION
`project.toml` and `pip install .` with extra indices don't go well, so we need to cheat a bit by setting the environment with `pip config set`.
This allows CFML and pydiff2 to be properly installed when doing pip install.