### PR TITLE
Added missing conversion field

### DIFF
--- a/src/easydiffraction/calculators/cryspy/parser.py
+++ b/src/easydiffraction/calculators/cryspy/parser.py
@@ -1917,6 +1917,7 @@ def cifV2ToV1_tof(edCif):
         '_model.cif_file_name': '_model_cif_file_name',
         '_experiment.cif_file_name': '_experiment_cif_file_name',
         '_audit_contact_author.name': '_audit.contact_author_name',  # Temporary fix for CrysPy to accept CIFs
+        '_audit_contact_author.email': '_audit.contact_author_email',  # Temporary fix for CrysPy to accept CIFs
         '_audit_contact_author.id_orcid': '_audit.contact_author_id_orcid',  # Temporary fix for CrysPy to accept CIFs
     }
     edToCryspyNamesMap['cwl'] = {


### PR DESCRIPTION
SCIPP generated data contains proper `_audit_contact_author` entries with `name`, `email`, and `orcid`.
Whereas we convert `name` and `orcid` to CIF v1, suitable for CIF ingestion, the `_audit_contact_author.email` entry remained unchanged.
This caused Cryspy to fail on reading the generated CIF.