### PR TITLE
pinned cryspy release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = '>=3.9,<3.13'
 dependencies = [
-  'cryspy',              # Calculations of diffraction patterns
+  'cryspy == 0.7.8',     # Calculations of diffraction patterns
   'easycrystallography', # Crystallography tools of the EasyScience framework
   'easyscience',         # The base library of the EasyScience framework
   'pooch',               # For data fetching


### PR DESCRIPTION
bugfix patch

A "rogue" release of cryspy has been causing issues with integration testing. Let's revise our original strategy of unpinning all the dependencies for the release and go back to 0.7.8.

This will be reverted to unpinned, when cryspy releases stable code.
